### PR TITLE
Enabling defaultlocOnly works, but also sends empty latitude and longitude.

### DIFF
--- a/zackwatch-config/index.html
+++ b/zackwatch-config/index.html
@@ -167,7 +167,7 @@
   var defaultlocbox = document.getElementById('defaultlocOnly_input');
   defaultlocbox.addEventListener('change', function() {
   console.log('checkbox changed');
-  if (dfaultlocbox.checked == true) {
+  if (defaultlocbox.checked == true) {
     console.log('using default loc')
     document.getElementById('longitude_input').value = '0.1278';
     document.getElementById('latitude_input').value = '51.5074';

--- a/zackwatch-config/index.html
+++ b/zackwatch-config/index.html
@@ -163,5 +163,26 @@
   </div>
 <script src='js/slate.min.js' type="text/javascript"></script>
 <script src='js/main.js' type="text/javascript"></script>
+<script>
+  var defaultlocbox = document.getElementById('defaultlocOnly_input');
+  defaultlocbox.addEventListener('change', function() {
+  console.log('checkbox changed');
+  if (dfaultlocbox.checked == true) {
+    console.log('using default loc')
+    document.getElementById('longitude_input').value = '0.1278';
+    document.getElementById('latitude_input').value = '51.5074';
+    document.getElementById('longitude_input').disabled = 'disabled';
+    document.getElementById('latitude_input').disabled = 'disabled';
+  }
+  else {
+    console.log('Using GPS loc')
+    document.getElementById('longitude_input').value = '';
+    document.getElementById('latitude_input').value = '';
+    document.getElementById('longitude_input').disabled = false;
+    document.getElementById('latitude_input').disabled = false;
+  }
+}
+);
+</script>
 </body>
 </html>


### PR DESCRIPTION
getPeople() then requests a bad forecast.io URL, which breaks javascript and nothing makes it back to the pebble.
